### PR TITLE
Initial api

### DIFF
--- a/decisions/api/__init__.py
+++ b/decisions/api/__init__.py
@@ -1,0 +1,5 @@
+from .action import ActionViewSet  # noqa
+from .case import CaseViewSet  # noqa
+from .category import CaseCategoryViewSet  # noqa
+from .event import EventViewSet  # noqa
+from .organization import OrganizationViewSet  # noqa

--- a/decisions/api/action.py
+++ b/decisions/api/action.py
@@ -1,0 +1,21 @@
+from rest_framework import serializers, viewsets
+from decisions.models import Action, Content
+
+
+class ContentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Content
+        exclude = ('id', 'action')
+
+
+class ActionSerializer(serializers.ModelSerializer):
+    contents = ContentSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Action
+        fields = '__all__'
+
+
+class ActionViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Action.objects.all()
+    serializer_class = ActionSerializer

--- a/decisions/api/case.py
+++ b/decisions/api/case.py
@@ -8,7 +8,6 @@ class CaseSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-
 class CaseViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Case.objects.all()
     serializer_class = CaseSerializer

--- a/decisions/api/case.py
+++ b/decisions/api/case.py
@@ -1,0 +1,14 @@
+from rest_framework import serializers, viewsets
+from decisions.models import Case
+
+
+class CaseSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Case
+        fields = '__all__'
+
+
+
+class CaseViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Case.objects.all()
+    serializer_class = CaseSerializer

--- a/decisions/api/category.py
+++ b/decisions/api/category.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers, viewsets
+from decisions.models import Category
+
+
+class CaseCategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Category
+        fields = '__all__'
+
+
+class CaseCategoryViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Category.objects.all()
+    serializer_class = CaseCategorySerializer

--- a/decisions/api/event.py
+++ b/decisions/api/event.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers, viewsets
+from decisions.models import Event
+
+
+class EventSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Event
+        fields = '__all__'
+
+
+class EventViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Event.objects.all()
+    serializer_class = EventSerializer

--- a/decisions/api/organization.py
+++ b/decisions/api/organization.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers, viewsets
+from decisions.models import Organization
+
+
+class OrganizationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Organization
+        fields = '__all__'
+
+
+class OrganizationViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Organization.objects.all()
+    serializer_class = OrganizationSerializer

--- a/decisions/factories/__init__.py
+++ b/decisions/factories/__init__.py
@@ -1,0 +1,3 @@
+from .case import ActionFactory, CaseFactory, CategoryFactory  # noqa
+from .event import EventFactory  # noqa
+from .organization import OrganizationFactory  # noqa

--- a/decisions/factories/case.py
+++ b/decisions/factories/case.py
@@ -1,0 +1,33 @@
+import factory
+from faker import Faker
+from decisions.models import Action, Case, Category
+
+fake = Faker()
+fake.seed(7)
+
+
+class CategoryFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Category
+    name = fake.text(max_nb_chars=20)
+
+
+class CaseFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Case
+
+    title = fake.text(max_nb_chars=50)
+    summary = fake.paragraph(nb_sentences=5)
+    register_id = factory.Sequence(lambda n: 'HEL 2016-{:0>6}'.format(n))
+    creation_date = fake.date()
+    category = factory.SubFactory(CategoryFactory)
+
+
+class ActionFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Action
+
+    title = fake.text(max_nb_chars=50)
+    case = factory.SubFactory(CaseFactory)
+    resolution = 'proposed'
+    ordering = factory.Sequence(lambda n: n)

--- a/decisions/factories/event.py
+++ b/decisions/factories/event.py
@@ -1,0 +1,15 @@
+import factory
+from faker import Faker
+from decisions.models import Event
+
+fake = Faker()
+fake.seed(7)
+
+
+class EventFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Event
+
+    name = fake.text(max_nb_chars=20)
+    description = fake.paragraph(nb_sentences=5)
+    start_date = fake.date()

--- a/decisions/factories/organization.py
+++ b/decisions/factories/organization.py
@@ -1,0 +1,17 @@
+import factory
+from faker import Faker
+from decisions.models import Organization
+
+fake = Faker()
+fake.seed(7)
+
+
+class OrganizationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Organization
+
+    name = fake.company()
+    abstract = fake.paragraph(nb_sentences=1)
+    description = fake.paragraph(nb_sentences=5)
+    classification = fake.company_suffix()
+    founding_date = fake.date()

--- a/decisions/tests/conftest.py
+++ b/decisions/tests/conftest.py
@@ -1,0 +1,9 @@
+from pytest_factoryboy import register
+
+from decisions.factories import ActionFactory, CaseFactory, CategoryFactory, EventFactory, OrganizationFactory
+
+register(ActionFactory)
+register(CaseFactory)
+register(CategoryFactory)
+register(EventFactory)
+register(OrganizationFactory)

--- a/decisions/tests/test_api.py
+++ b/decisions/tests/test_api.py
@@ -1,0 +1,25 @@
+import pytest
+from rest_framework.reverse import reverse
+
+
+@pytest.mark.parametrize('resource', [
+    'action',
+    'case',
+    'category',
+    'event',
+    'organization',
+])
+@pytest.mark.django_db
+def test_smoke_get(client, resource, action, case, category, event, organization):
+    """
+    Test GET to every resource's list and detail endpoint.
+    """
+    list_url = reverse('v1:%s-list' % resource)
+    response = client.get(list_url)
+    assert response.status_code == 200
+    assert len(response.data['results'])
+
+    detail_url = reverse('v1:%s-detail' % resource, kwargs={'pk': locals().get(resource).id})
+    response = client.get(detail_url)
+    assert response.status_code == 200
+    assert response.data

--- a/decisions/tests/test_dummy.py
+++ b/decisions/tests/test_dummy.py
@@ -1,7 +1,0 @@
-import pytest
-from django.apps import apps
-
-
-@pytest.mark.django_db
-def test_apps_exist():
-    assert list(apps.get_models())

--- a/decisions/urls_v1.py
+++ b/decisions/urls_v1.py
@@ -1,0 +1,15 @@
+from django.conf.urls import include, url
+from rest_framework.routers import DefaultRouter
+
+from decisions.api import ActionViewSet, CaseViewSet, CaseCategoryViewSet, EventViewSet, OrganizationViewSet
+
+router = DefaultRouter()
+router.register(r'action', ActionViewSet)
+router.register(r'case', CaseViewSet)
+router.register(r'case_category', CaseCategoryViewSet)
+router.register(r'event', EventViewSet)
+router.register(r'organization', OrganizationViewSet)
+
+urlpatterns = [
+    url(r'^', include(router.urls, namespace='v1')),
+]

--- a/paatos/settings.py
+++ b/paatos/settings.py
@@ -91,6 +91,13 @@ LOGGING = {
 }
 
 
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 20,
+    'DEFAULT_PERMISSION_CLASS': 'rest_framework.permissions.IsAuthenticatedOrReadOnly',
+}
+
+
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.
 f = os.path.join(BASE_DIR, "local_settings.py")

--- a/paatos/urls.py
+++ b/paatos/urls.py
@@ -1,7 +1,8 @@
-from django.conf.urls import url
+from django.conf.urls import include, url
 from django.contrib import admin
+from decisions import urls_v1
 
 urlpatterns = [
+    url(r'^v1/', include(urls_v1)),
     url(r'^admin/', admin.site.urls),
-    # url(r'^', include("decisions.urls")),
 ]


### PR DESCRIPTION
Implemented initial read-only API with endpoints action, case, case_category, event and organization. Added also factoryboy based test data factories and smoke tests for all the endpoints.
